### PR TITLE
Input Password Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,16 @@ function prompt (message, hideInput, cb) {
       if (key.ctrl && key.name === 'c') {
         process.exit();
       }
-      else if (key.name === 'return') {
+      else if (key.name === 'return'){
+        if (hideInput == true){
+          process.stdin.removeListener('keypress', listen);
+          process.stdin.pause();
+          setRawMode(false);
+          console.log();
+          cb(line, function () {}); // for backwards-compatibility, fake end() callback
+        }
+        return;
+      } else if (key.name === 'enter') {
         process.stdin.removeListener('keypress', listen);
         process.stdin.pause();
         if (hideInput) {


### PR DESCRIPTION
Last fix did not work as it broke functionality on Unix/OSX (ends of
lines in those OSs are NL, in Windows it is CRLF).

Have tried another solution:
- Readded key.name === 'enter'. This works for all commands, except for
  password when input is hidden (when setRawMode is set to true).
- Added a separate check for key.name === 'return', which ONLY catches
  when hideInput is true.
